### PR TITLE
keep matrix class

### DIFF
--- a/R/spark.R
+++ b/R/spark.R
@@ -95,7 +95,7 @@ CreateSPARKObject <- function(counts, location, project = "SPARK", percentage = 
 	## filtering out lowly expressed genes
 	if(percentage > 0){
 		gene_use <- which( rowSums(object.counts > 0) >= floor(percentage*ncol(object.counts)) )
-		object.counts	<- object.counts[gene_use, ]
+		object.counts	<- object.counts[gene_use, , drop=FALSE]
 	}# end fi
   
 	## filter cells that are quite a few number of genes expressed


### PR DESCRIPTION
On the rare occasion that a single gene is left for testing. This avoids crashing when a single gene is left in the data set.